### PR TITLE
docs: input por voz — freeform e gravar reunião

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -30,7 +30,8 @@
             "pages": [
               "product/workspaces",
               "product/sessions",
-              "product/agents"
+              "product/agents",
+              "product/voice-input"
             ]
           },
           {

--- a/product/voice-input.mdx
+++ b/product/voice-input.mdx
@@ -1,0 +1,45 @@
+---
+title: "Input por Voz"
+description: "Dite mensagens e transcreva reuniões diretamente no G4 OS usando reconhecimento de voz em tempo real."
+---
+
+## Fale em vez de digitar
+
+O G4 OS permite usar a voz como forma de entrada em qualquer momento da conversa. Em vez de digitar uma instrução longa, você pode falar e o texto aparece automaticamente no campo de input.
+
+A transcrição acontece em tempo real, via Gemini Live, sem necessidade de pausas ou confirmações manuais.
+
+## Onde o input por voz aparece
+
+### Freeform input
+
+No campo de texto padrão das sessões, o ícone de microfone ativa a escuta ao vivo. Enquanto você fala, o texto vai sendo preenchido. Ao terminar, é só enviar normalmente.
+
+Útil para:
+
+- instruções longas que seriam trabalhosas de digitar
+- brainstorming rápido
+- ditar rascunhos e contextos extensos
+
+### Gravar reunião
+
+O G4 OS também permite iniciar a gravação de uma reunião diretamente pela sessão. O áudio é transcrito em tempo real e o resultado fica disponível como contexto para o agente trabalhar.
+
+Útil para:
+
+- capturar decisões e próximos passos sem precisar anotar
+- criar resumos automáticos após a reunião
+- alimentar o contexto de uma sessão com o que foi discutido
+
+## Requisitos
+
+O input por voz requer entitlement específico habilitado na sua conta. Se o ícone de microfone não aparecer, entre em contato com o suporte.
+
+<Card
+  title="Ver sessões"
+  icon="messages"
+  href="/product/sessions"
+  horizontal
+>
+  Entenda como o contexto capturado por voz se integra ao histórico de cada sessão.
+</Card>


### PR DESCRIPTION
## O que essa PR faz

Adiciona a página `product/voice-input.mdx` documentando as duas modalidades de input por voz do G4 OS:

- **Freeform input** — microfone no campo de texto, transcrição ao vivo via Gemini Live
- **Gravar reunião** — captura e transcreve reuniões como contexto para a sessão

Também atualiza `docs.json` para incluir a página no grupo Plataforma.

Closes #3