### PR TITLE
docs: adiciona YouTube, HubSpot e Salesforce ao catálogo de conexões gerenciadas

### DIFF
--- a/product/connections/managed-connections.mdx
+++ b/product/connections/managed-connections.mdx
@@ -20,7 +20,7 @@ Elas reduzem o trabalho manual de configuração, porque o produto já cuida de 
 - quando o time precisa de uma integração estável sem montar infraestrutura própria
 - quando você quer velocidade para colocar a operação no ar
 
-Hoje, o catálogo padrão do G4 OS reúne `24 conexões gerenciadas`.
+Hoje, o catálogo padrão do G4 OS reúne `27 conexões gerenciadas`.
 
 ## Catálogo atual
 
@@ -108,6 +108,15 @@ Hoje, o catálogo padrão do G4 OS reúne `24 conexões gerenciadas`.
   </Card>
   <Card title="Trello" icon="https://trello.com/favicon.ico">
     Acompanhar quadros, cards e organização de trabalho no Trello.
+  </Card>
+  <Card title="HubSpot" icon="https://pipedream.com/s.v0/app_OkrhlP/logo/orig">
+    Trabalhar com CRM, contatos, empresas e negócios no HubSpot.
+  </Card>
+  <Card title="Salesforce" icon="https://pipedream.com/s.v0/app_OrZhD7/logo/orig">
+    Consultar objetos, registros e apoiar ações comerciais no Salesforce.
+  </Card>
+  <Card title="YouTube" icon="https://pipedream.com/s.v0/app_XKvhQ3/logo/orig">
+    Acessar vídeos, playlists, comentários e dados do canal via YouTube.
   </Card>
 </Columns>
 


### PR DESCRIPTION
## Relacionado

Closes #6

## O que muda

- Atualiza o total de conexões gerenciadas de `24` para `27`
- Adiciona três novos cards na seção **Operação e colaboração**:

| Conector | Ícone | Descrição |
|---|---|---|
| HubSpot | `pipedream.com/s.v0/app_OkrhlP/logo/orig` | CRM, contatos, empresas e negócios |
| Salesforce | `pipedream.com/s.v0/app_OrZhD7/logo/orig` | Objetos, registros e ações comerciais |
| YouTube | `pipedream.com/s.v0/app_XKvhQ3/logo/orig` | Vídeos, playlists, comentários e canal |

Ícones extraídos dos `config.json` dos connectors em `apps/electron/resources/default-workspace/sources/`.

## Origem

Commit `133fd880` — _Add managed YouTube, HubSpot, and Salesforce connectors_