### PR TITLE
docs: documenta ação 'Review tags with assistant' no painel de sessões

### DIFF
--- a/support/tags.mdx
+++ b/support/tags.mdx
@@ -29,6 +29,18 @@ Tags ajudam a organizar sessões com marcadores reutilizáveis e, quando necess�
 - [Abrir Tags](g4os://settings/labels)
 - [Abrir Sessões](g4os://allSessions)
 
+## Revisar tags com o assistente
+
+O painel de sessões tem um atalho para abrir uma nova sessão já preparada para revisar a estrutura de tags do workspace.
+
+Ao clicar em **Review tags with assistant** (ícone de edição no cabeçalho do painel de tags), o assistente recebe automaticamente o prompt:
+
+> _Explain the current tag structure and auto-apply rules, suggest improvements, and guide me through the update process. Do not edit anything yet; ask for confirmation first._
+
+Você também pode abrir essa sessão diretamente pelo deep link:
+
+- [Revisar tags com o assistente](g4os://action/new-session?input=Explain%20the%20current%20tag%20structure%20and%20auto-apply%20rules%2C%20suggest%20improvements%2C%20and%20guide%20me%20through%20the%20update%20process.%20Do%20not%20edit%20anything%20yet%3B%20ask%20for%20confirmation%20first.&send=true&mode=ask&workdir=none)
+
 ## Dica prática
 
 Se as tags estão sendo usadas só como lista plana, vale revisar a hierarquia e as regras automáticas. Isso normalmente melhora bastante a navegabilidade.


### PR DESCRIPTION
## Relacionado

Closes #7

## O que muda

Adiciona seção **"Revisar tags com o assistente"** em `support/tags.mdx` documentando:

- O atalho no painel de tags (ícone de edição no cabeçalho)
- O prompt disparado automaticamente ao clicar
- Deep link `g4os://` para abrir a sessão diretamente, com o prompt já encodado na URL

### Deep link gerado

```
g4os://action/new-session?input=Explain%20the%20current%20tag%20structure...&send=true&mode=ask&workdir=none
```

Formato extraído de `AppShell.tsx` — segue o mesmo padrão de outros launchers de sessão com prompt pré-preenchido.

## Origem

Commit `24895239` — _Add tag review session launcher_