### PR TITLE
docs(connections): document managed provider hint in model selector

### DIFF
--- a/product/connections/managed-connections.mdx
+++ b/product/connections/managed-connections.mdx
@@ -9,9 +9,16 @@ Conexões gerenciadas são integrações prontas do catálogo do G4 OS.
 
 Elas reduzem o trabalho manual de configuração, porque o produto já cuida de partes importantes como autenticação, reconexão, status e experiência de uso dentro da sessão.
 
+## Indicador de provedor na sessão
+
+Quando o G4 OS está operando com o provedor gerenciado ativo, o seletor de modelo na área de input exibe o hint **"G4 Managed Provider by AWS"**.
+
+Esse indicador aparece automaticamente em builds públicas do G4 OS sempre que uma conexão gerenciada está sendo usada — sem necessidade de configuração adicional. O objetivo é dar transparência ao usuário sobre qual provedor está processando as requisições da sessão atual.
+
 ## Onde aparecem no produto
 
 - `Fontes > Conexões Gerenciadas`
+- Indicador **"G4 Managed Provider by AWS"** no seletor de modelo da área de input (durante sessões ativas)
 - [Abrir Conexões Gerenciadas](g4os://sources/g4-managed)
 
 ## Quando vale começar por aqui


### PR DESCRIPTION
## Summary

Adiciona seção **Indicador de provedor na sessão** em `product/connections/managed-connections.mdx` documentando o hint "G4 Managed Provider by AWS" que aparece no seletor de modelo da área de input.

## O que foi documentado

- O hint exibe automaticamente em builds públicas quando uma conexão gerenciada está ativa
- Label exibido: **"G4 Managed Provider by AWS"**
- Objetivo do indicador: transparência sobre qual provedor está processando as requisições

## Closes

Closes #18

🤖 Generated with [G4 OS](https://g4oscloud.com)