### PR TITLE
fix(docs): replace 'G4 Educação' with 'G4' in company-context and workspace

### DIFF
--- a/support/company-context.mdx
+++ b/support/company-context.mdx
@@ -31,13 +31,13 @@ Empresas verificadas exibem um **badge azul** ao lado do nome em:
 - Header de admin da empresa
 - Viewer list
 
-Esse badge indica que a empresa foi validada pelo G4 Educação como a organização real correspondente àquele cadastro.
+Esse badge indica que a empresa foi validada pelo G4 como a organização real correspondente àquele cadastro.
 
 ### Por que a verificação existe
 
 A verificação resolve um problema prático: garantir que os colaboradores saibam que estão se conectando à **empresa real**, e não a um cadastro duplicado, desatualizado ou criado por engano.
 
-Sem verificação, qualquer usuário com acesso ao admin poderia criar uma empresa com o mesmo nome. O badge azul é a confirmação de que o G4 Educação validou aquela entidade.
+Sem verificação, qualquer usuário com acesso ao admin poderia criar uma empresa com o mesmo nome. O badge azul é a confirmação de que o G4 validou aquela entidade.
 
 ## Critérios para verificação
 
@@ -45,9 +45,9 @@ Para que uma empresa seja elegível à verificação, ela deve atender a **todos
 
 1. **Assinatura ativa** — a empresa precisa ter um plano pago vigente no G4 OS
 2. **Mínimo de 10 usuários com seats pagantes ativos** — a conta deve ter ao menos 10 membros com licença paga ativa no momento da solicitação
-3. **Solicitação formal ao G4 Educação** — o admin da empresa deve abrir uma solicitação oficial, acompanhada de documentação que comprove tratar-se da empresa real (contrato social, CNPJ, ou documento equivalente)
+3. **Solicitação formal ao G4** — o admin da empresa deve abrir uma solicitação oficial, acompanhada de documentação que comprove tratar-se da empresa real (contrato social, CNPJ, ou documento equivalente)
 
-Após a análise e aprovação pelo G4 Educação, um admin do sistema marca a empresa como verificada no painel de administração.
+Após a análise e aprovação pelo G4, um admin do sistema marca a empresa como verificada no painel de administração.
 
 ## Relação com a gestão de usuários
 
@@ -61,7 +61,7 @@ Administradores podem acompanhar o status de membros e seats no painel da empres
 
 ## Quem pode solicitar verificação
 
-Apenas **admins da empresa** no G4 OS podem iniciar o processo de verificação. O pedido deve ser feito diretamente ao suporte do G4 Educação com a documentação necessária.
+Apenas **admins da empresa** no G4 OS podem iniciar o processo de verificação. O pedido deve ser feito diretamente ao suporte do G4 com a documentação necessária.
 
 ## O que muda após a verificação
 

--- a/support/workspace.mdx
+++ b/support/workspace.mdx
@@ -48,7 +48,7 @@ Depois que o workspace já existe, a área de `Workspace` vira o lugar certo par
 
 O **Company Context** vincula este workspace a uma empresa cadastrada no G4 OS. Com o vínculo ativo, os agentes nas sessões passam a acessar o contexto organizacional dessa empresa automaticamente.
 
-Empresas verificadas exibem um **badge azul** ao lado do nome no seletor. Esse badge indica que o G4 Educação validou que aquele cadastro corresponde à empresa real — garantindo que os colaboradores saibam que estão se conectando ao contexto correto.
+Empresas verificadas exibem um **badge azul** ao lado do nome no seletor. Esse badge indica que o G4 validou que aquele cadastro corresponde à empresa real — garantindo que os colaboradores saibam que estão se conectando ao contexto correto.
 
 <Card
   title="Saiba mais sobre Company Context e verificação"


### PR DESCRIPTION
6 ocorrências de 'G4 Educação' substituídas por 'G4' nos arquivos:
- `support/company-context.mdx` (5 ocorrências)
- `support/workspace.mdx` (1 ocorrência)

🤖 Generated with [G4 OS](https://g4oscloud.com)